### PR TITLE
Handle invalid login errors gracefully

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -27,7 +27,11 @@ function LoginPage() {
       await signIn(email, password);
       navigate(from, { replace: true });
     } catch (err: any) {
-      setError(err.message || 'Failed to sign in');
+      if (err?.status && err.status >= 400) {
+        setError(err.message || 'Invalid email or password');
+      } else {
+        setError(err.message || 'Failed to sign in');
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- show friendlier login error messages when the server returns an error

## Testing
- `npm run lint` *(fails: 20 errors, 3 warnings)*