### PR TITLE
Add collage export feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "react-router-dom": "^7.6.0",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
-    "zustand": "^5.0.4"
+    "zustand": "^5.0.4",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import html2canvas from 'html2canvas'
+import { jsPDF } from 'jspdf'
+import { Modal } from './Modal'
+
+interface ExportButtonProps {
+targetRef: React.RefObject<HTMLElement>
+}
+
+type Format = 'png' | 'jpeg' | 'pdf'
+
+/**
+ * Button and modal for exporting a collage element as an image or PDF
+ */
+function ExportButton({ targetRef }: ExportButtonProps) {
+const [open, setOpen] = useState(false)
+const [preview, setPreview] = useState<string | null>(null)
+const [format, setFormat] = useState<Format>('png')
+const [processing, setProcessing] = useState(false)
+const [error, setError] = useState<string | null>(null)
+
+const generatePreview = async () => {
+if (!targetRef.current) return
+setProcessing(true)
+setError(null)
+try {
+const canvas = await html2canvas(targetRef.current, { scale: 2 })
+const mime = format === 'pdf' ? 'image/png' : `image/${format}`
+setPreview(canvas.toDataURL(mime))
+} catch {
+setError('Failed to capture collage')
+}
+setProcessing(false)
+}
+
+const download = () => {
+if (!preview) return
+if (format === 'pdf') {
+const pdf = new jsPDF('p', 'mm', 'a4')
+const imgProps = pdf.getImageProperties(preview)
+const width = pdf.internal.pageSize.getWidth()
+const height = (imgProps.height * width) / imgProps.width
+pdf.addImage(preview, 'PNG', 0, 0, width, height)
+pdf.save('collage.pdf')
+} else {
+const link = document.createElement('a')
+link.href = preview
+link.download = `collage.${format}`
+link.click()
+}
+}
+
+const openModal = async () => {
+await generatePreview()
+setOpen(true)
+}
+
+return (
+<>
+<button
+onClick={openModal}
+className="px-3 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
+>
+Export
+</button>
+<Modal isOpen={open} onClose={() => setOpen(false)} title="Export Collage">
+{processing ? (
+<p className="text-center">Preparing...</p>
+) : (
+preview && (
+<div className="space-y-4">
+<img src={preview} alt="Preview" className="max-w-full" />
+<div className="flex items-center justify-between">
+<select
+value={format}
+onChange={(e) => setFormat(e.target.value as Format)}
+className="border rounded p-2"
+>
+<option value="png">PNG</option>
+<option value="jpeg">JPEG</option>
+<option value="pdf">PDF</option>
+</select>
+<button
+onClick={download}
+className="px-3 py-1.5 rounded-md bg-indigo-600 text-white hover:bg-indigo-700"
+>
+Download
+</button>
+</div>
+{error && <p className="text-red-500 text-sm">{error}</p>}
+</div>
+)
+)}
+</Modal>
+</>
+)
+}
+
+export default ExportButton

--- a/src/components/MediaGallery.tsx
+++ b/src/components/MediaGallery.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Grid, List, Calendar, Trash, Plus, Film, Sparkles, AlertCircle, Maximize2 } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { useMediaStore } from '../store/mediaStore';
@@ -10,6 +10,7 @@ import { MediaLightbox } from './MediaLightbox';
 
 import { Modal } from './Modal';
 import { QuickStoryDisplay } from '../utils/parseMarkdown';
+import ExportButton from './ExportButton';
 
 type ViewMode = 'grid' | 'timeline';
 
@@ -43,6 +44,7 @@ function MediaGallery() {
   const [quickStoryResult, setQuickStoryResult] = useState<{ summary: string; prompts: string[] } | null>(null);
   const [isGeneratingQuickStory, setIsGeneratingQuickStory] = useState(false);
   const [errorMessage, setErrorMessage] = useState<ErrorMessageType | null>(null);
+  const exportRef = useRef<HTMLDivElement>(null);
   
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
@@ -486,7 +488,14 @@ function MediaGallery() {
             {isGeneratingQuickStory ? 'Generating...' : '✨ Generate Story ✨'}
           </button>
 
-          <QuickStoryDisplay collageData={quickStoryResult} isLoading={isGeneratingQuickStory} />
+          <QuickStoryDisplay
+            collageData={quickStoryResult}
+            isLoading={isGeneratingQuickStory}
+            exportRef={exportRef}
+          />
+          {quickStoryResult && !isGeneratingQuickStory && (
+            <ExportButton targetRef={exportRef} />
+          )}
         </div>
       </Modal>
 

--- a/src/utils/parseMarkdown.tsx
+++ b/src/utils/parseMarkdown.tsx
@@ -5,8 +5,9 @@ import rehypeSanitize from 'rehype-sanitize';
 import rehypeRaw from 'rehype-raw';
 
 interface CollageDisplayProps {
-  collageData: { summary: string; prompts: string[] } | null;
-  isLoading: boolean;
+collageData: { summary: string; prompts: string[] } | null
+isLoading: boolean
+exportRef?: React.Ref<HTMLDivElement>
 }
 
 // Component for displaying markdown content with consistent styling
@@ -50,7 +51,7 @@ export const parseMarkdown = (markdown: string): string => {
   return markdown;
 };
 
-export const QuickStoryDisplay: React.FC<CollageDisplayProps> = ({ collageData, isLoading }) => {
+export const QuickStoryDisplay: React.FC<CollageDisplayProps> = ({ collageData, isLoading, exportRef }) => {
   // Force re-render with a key based on content hash
   const contentKey = collageData ? 
     `summary-${collageData.summary?.substring(0, 20)}` : 'no-content';
@@ -75,7 +76,7 @@ export const QuickStoryDisplay: React.FC<CollageDisplayProps> = ({ collageData, 
   console.log("Prompts to display:", collageData.prompts);
 
   return (
-    <div className="mt-4 py-4 border-t border-gray-200">
+    <div className="mt-4 py-4 border-t border-gray-200" ref={exportRef}>
       <h4 className="text-lg font-semibold text-gray-800 mb-2">Your AI Generated Story</h4>
       <div 
         key={contentKey}


### PR DESCRIPTION
## Summary
- allow exporting generated collages
- provide ExportButton component
- integrate export option into Quick Story modal
- support PNG, JPEG and PDF downloads

## Testing
- `npm run lint` *(fails: index variable unused and other existing issues)*
- `npm run build` *(fails: html2canvas module not resolved)*