### PR TITLE
Add mood/scene tagging system

### DIFF
--- a/src/components/TagFilter.tsx
+++ b/src/components/TagFilter.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react'
+import { useTagStore } from '../store/tagStore'
+
+export function TagFilter() {
+const { tags, selectedFilter, fetchTags, toggleFilterTag } = useTagStore()
+
+useEffect(() => {
+fetchTags()
+}, [fetchTags])
+
+return (
+<div className='flex flex-wrap gap-2 mb-4'>
+{tags.map(tag => (
+<label key={tag.id} className='flex items-center gap-1 text-sm'>
+<input
+type='checkbox'
+checked={selectedFilter.includes(tag.id)}
+onChange={() => toggleFilterTag(tag.id)}
+/>
+<span>{tag.name}</span>
+</label>
+))}
+</div>
+)
+}

--- a/src/components/TagManager.tsx
+++ b/src/components/TagManager.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react'
+import { Modal } from './Modal'
+import { useTagStore } from '../store/tagStore'
+
+interface TagManagerProps {
+mediaId: string
+isOpen: boolean
+onClose: () => void
+}
+
+export function TagManager({ mediaId, isOpen, onClose }: TagManagerProps) {
+const {
+tags,
+mediaTags,
+fetchTags,
+fetchMediaTags,
+createTag,
+addTagsToMedia,
+removeTagFromMedia,
+} = useTagStore()
+const [selected, setSelected] = useState<string[]>([])
+const [newTag, setNewTag] = useState('')
+
+useEffect(() => {
+if (!isOpen) return
+fetchTags()
+fetchMediaTags(mediaId).then(list => setSelected(list.map(t => t.id)))
+}, [isOpen, mediaId, fetchTags, fetchMediaTags])
+
+const toggle = (id: string) => {
+setSelected(prev =>
+prev.includes(id) ? prev.filter(t => t !== id) : [...prev, id]
+)
+}
+
+const handleSave = async () => {
+const current = mediaTags[mediaId]?.map(t => t.id) || []
+const add = selected.filter(id => !current.includes(id))
+const remove = current.filter(id => !selected.includes(id))
+if (add.length) await addTagsToMedia(mediaId, add)
+await Promise.all(remove.map(id => removeTagFromMedia(mediaId, id)))
+onClose()
+}
+
+const handleAdd = async () => {
+if (!newTag.trim()) return
+let tag = tags.find(t => t.name.toLowerCase() === newTag.toLowerCase())
+if (!tag) tag = await createTag(newTag) || undefined
+if (tag) toggle(tag.id)
+setNewTag('')
+}
+
+return (
+<Modal isOpen={isOpen} onClose={onClose} title='Edit Tags'>
+<div className='space-y-4'>
+<div className='flex flex-wrap gap-2'>
+{tags.map(t => (
+<label key={t.id} className='flex items-center gap-1 text-sm'>
+<input
+type='checkbox'
+checked={selected.includes(t.id)}
+onChange={() => toggle(t.id)}
+/>
+<span>{t.name}</span>
+</label>
+))}
+</div>
+<div className='flex gap-2'>
+<input
+className='border px-2 py-1 flex-1'
+value={newTag}
+onChange={e => setNewTag(e.target.value)}
+placeholder='New tag'
+/>
+<button
+onClick={handleAdd}
+className='px-3 py-1 bg-indigo-600 text-white rounded'
+>
+Add
+</button>
+</div>
+<div className='flex justify-end gap-2'>
+<button
+onClick={onClose}
+className='px-4 py-2 border rounded'
+>
+Cancel
+</button>
+<button
+onClick={handleSave}
+className='px-4 py-2 bg-indigo-600 text-white rounded'
+>
+Save
+</button>
+</div>
+</div>
+</Modal>
+)
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -47,3 +47,17 @@ export type MediaCollection = {
   media_id: string;
   collection_id: string;
 };
+
+export interface Tag {
+id: string;
+user_id: string;
+name: string;
+created_at: string;
+updated_at: string;
+}
+
+export interface MediaTag {
+id: string;
+media_id: string;
+tag_id: string;
+}

--- a/src/pages/GalleryPage.tsx
+++ b/src/pages/GalleryPage.tsx
@@ -3,6 +3,7 @@ import { Plus, Image } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import MediaGallery from '../components/MediaGallery';
+import { TagFilter } from '../components/TagFilter';
 import { Collection, Media } from '../lib/supabase';
 import { useMediaStore } from '../store/mediaStore';
 import { useCollectionStore } from '../store/collectionStore';
@@ -66,7 +67,10 @@ function GalleryPage() {
       </div>
       
       {activeTab === 'media' ? (
-        <MediaGallery />
+        <>
+          <TagFilter />
+          <MediaGallery />
+        </>
       ) : (
         <>
           <div className="flex justify-between items-center mb-6">

--- a/src/store/tagStore.ts
+++ b/src/store/tagStore.ts
@@ -1,0 +1,102 @@
+import { create } from 'zustand'
+import { supabase, Tag } from '../lib/supabase'
+
+interface TagState {
+tags: Tag[]
+mediaTags: Record<string, Tag[]>
+selectedFilter: string[]
+loading: boolean
+error: string | null
+fetchTags: () => Promise<void>
+fetchMediaTags: (mediaId: string) => Promise<Tag[]>
+createTag: (name: string) => Promise<Tag | null>
+addTagsToMedia: (mediaId: string, tagIds: string[]) => Promise<void>
+removeTagFromMedia: (mediaId: string, tagId: string) => Promise<void>
+toggleFilterTag: (tagId: string) => void
+}
+
+export const useTagStore = create<TagState>((set, get) => ({
+tags: [],
+mediaTags: {},
+selectedFilter: [],
+loading: false,
+error: null,
+
+fetchTags: async () => {
+set({ loading: true })
+const { data, error } = await supabase
+.from('tags')
+.select('*')
+.order('name')
+if (error) {
+set({ error: error.message, loading: false })
+return
+}
+set({ tags: data as Tag[], loading: false })
+},
+
+fetchMediaTags: async (mediaId: string) => {
+const { data, error } = await supabase
+.from('media_tags')
+.select('tags(*)')
+.eq('media_id', mediaId)
+if (error) {
+set({ error: error.message })
+return []
+}
+const tagList = (data || []).map(mt => mt.tags as Tag)
+set({ mediaTags: { ...get().mediaTags, [mediaId]: tagList } })
+return tagList
+},
+
+createTag: async (name: string) => {
+const { data: auth } = await supabase.auth.getUser()
+const userId = auth.user?.id
+if (!userId) return null
+const { data, error } = await supabase
+.from('tags')
+.insert({ name, user_id: userId })
+.select()
+.single()
+if (error) {
+set({ error: error.message })
+return null
+}
+set({ tags: [...get().tags, data as Tag] })
+return data as Tag
+},
+
+addTagsToMedia: async (mediaId: string, tagIds: string[]) => {
+const inserts = tagIds.map(id => ({ media_id: mediaId, tag_id: id }))
+const { error } = await supabase.from('media_tags').insert(inserts)
+if (error) {
+set({ error: error.message })
+return
+}
+const current = get().mediaTags[mediaId] || []
+const added = get().tags.filter(t => tagIds.includes(t.id))
+set({ mediaTags: { ...get().mediaTags, [mediaId]: [...current, ...added] } })
+},
+
+removeTagFromMedia: async (mediaId: string, tagId: string) => {
+const { error } = await supabase
+.from('media_tags')
+.delete()
+.match({ media_id: mediaId, tag_id: tagId })
+if (error) {
+set({ error: error.message })
+return
+}
+const remaining = (get().mediaTags[mediaId] || []).filter(t => t.id !== tagId)
+set({ mediaTags: { ...get().mediaTags, [mediaId]: remaining } })
+},
+
+toggleFilterTag: (tagId: string) => {
+const list = get().selectedFilter
+set({
+selectedFilter: list.includes(tagId)
+? list.filter(id => id !== tagId)
+: [...list, tagId],
+})
+},
+}))

--- a/supabase/migrations/20250510120000_add_tags.sql
+++ b/supabase/migrations/20250510120000_add_tags.sql
@@ -1,0 +1,64 @@
+-- Add tags and media_tags tables
+
+CREATE TABLE IF NOT EXISTS tags (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) NOT NULL,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS media_tags (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  media_id UUID REFERENCES media(id) ON DELETE CASCADE NOT NULL,
+  tag_id UUID REFERENCES tags(id) ON DELETE CASCADE NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  UNIQUE(media_id, tag_id)
+);
+
+ALTER TABLE tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE media_tags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own tags"
+  ON tags FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own tags"
+  ON tags FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own tags"
+  ON tags FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own tags"
+  ON tags FOR DELETE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can view their own media_tags"
+  ON media_tags FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM media m
+      WHERE m.id = media_id AND m.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert their own media_tags"
+  ON media_tags FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM media m
+      WHERE m.id = media_id AND m.user_id = auth.uid()
+    ) AND
+    EXISTS (
+      SELECT 1 FROM tags t
+      WHERE t.id = tag_id AND t.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete their own media_tags"
+  ON media_tags FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM media m
+      WHERE m.id = media_id AND m.user_id = auth.uid()
+    )
+  );
+
+CREATE TRIGGER set_tags_updated_at
+BEFORE UPDATE ON tags
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- create Supabase migration for tags
- add Tag entity types
- manage tags via new Zustand store
- provide TagManager modal and TagFilter UI
- integrate tagging into media gallery and gallery page

## Testing
- `npm run lint` *(fails: Unexpected any errors)*