### PR TITLE
Add Jest config and testing utilities

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest'
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/test/setupTests.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {},
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+}
+
+export default config

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
@@ -46,7 +47,14 @@
     "typescript-eslint": "^8.32.0",
     "vite": "^6.3.5",
     "vite-plugin-pwa": "^1.0.0",
-    "workbox-window": "^7.3.0"
+    "workbox-window": "^7.3.0",
+    "@testing-library/jest-dom": "^6.4.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0"
   },
   "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
 }

--- a/src/features/collage/CollageGrid.test.tsx
+++ b/src/features/collage/CollageGrid.test.tsx
@@ -1,0 +1,13 @@
+import { renderWithProviders } from '../../test/test-utils'
+import CollageGrid from './CollageGrid'
+
+const images = [
+  { id: '1', url: 'image1.jpg' },
+]
+
+test('renders collage items', () => {
+  const { getByRole } = renderWithProviders(
+    <CollageGrid images={images} />,
+  )
+  expect(getByRole('img')).toBeInTheDocument()
+})

--- a/src/test/MockProviders.tsx
+++ b/src/test/MockProviders.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { AuthProvider } from '../utils/auth'
+
+interface Props {
+  children: ReactNode
+}
+
+/**
+ * Wraps children with test providers.
+ */
+export default function MockProviders({ children }: Props) {
+  return (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  )
+}

--- a/src/test/setupTests.ts
+++ b/src/test/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import MockProviders from './MockProviders'
+
+/**
+ * Render a component wrapped with default test providers.
+ */
+export function renderWithProviders(ui: ReactElement, route = '/') {
+  window.history.pushState({}, 'Test page', route)
+  return render(ui, { wrapper: MockProviders })
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,5 +20,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "src/test"]
 }


### PR DESCRIPTION
## Summary
- add Jest configuration and initial test dependencies
- provide test helpers and mock providers
- create example test for `CollageGrid`
- include testing support folder in tsconfig

## Testing
- `npm test` *(fails: jest not found)*