### PR TITLE
Add testing utilities and config

### DIFF
--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -1,0 +1,10 @@
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+
+export const handlers = [
+  rest.get('/health', (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({ status: 'ok' })),
+  ),
+]
+
+export const server = setupServer(...handlers)

--- a/src/test/mocks/providers.tsx
+++ b/src/test/mocks/providers.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { AuthProvider } from '../../utils/auth'
+
+interface ProvidersProps {
+  children: ReactNode
+}
+
+export function AllProviders({ children }: ProvidersProps) {
+  return (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  )
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,11 @@
+import { afterAll, afterEach, beforeAll } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { server } from './mocks/handlers'
+import '@testing-library/jest-dom'
+
+beforeAll(() => server.listen())
+afterEach(() => {
+  server.resetHandlers()
+  cleanup()
+})
+afterAll(() => server.close())

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,0 +1,12 @@
+export * from '@testing-library/react'
+export { default as userEvent } from '@testing-library/user-event'
+import type { ReactElement } from 'react'
+import { render, RenderOptions } from '@testing-library/react'
+import { AllProviders } from './mocks/providers'
+
+export function renderWithProviders(
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) {
+  return render(ui, { wrapper: AllProviders, ...options })
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- add MSW handlers and server setup
- create mock auth and router providers
- provide render helper for tests
- configure Vitest to use jsdom and setup file

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx vitest run` *(fails: command not found or missing dependencies)*